### PR TITLE
Add ways to manipulate unknown sections

### DIFF
--- a/src/oByteLib.mli
+++ b/src/oByteLib.mli
@@ -41,10 +41,9 @@ end
 (** Tool to manipulate section names *)
 module Section : sig
   (** Bytecode files are divided into sections represented by a 4-letter name *)
-  type t = CODE | DLPT | DLLS | PRIM | DATA | SYMB | CRCS | DBUG
+  type t = CODE | DLPT | DLLS | PRIM | DATA | SYMB | CRCS | DBUG | Unknown of string
 
-  (** Convert a 4-letter string to it associated constructor. Raise a
-      Failure if no section match *)
+  (** Convert a 4-letter string to it associated constructor. *)
   val of_string : string -> t
 
   (** Convert a construtor to its 4-letter associated name *)

--- a/src/section.ml
+++ b/src/section.ml
@@ -10,12 +10,20 @@
 (*************************************************************************)
 
 type t = CODE | DLPT | DLLS | PRIM | DATA | SYMB | CRCS | DBUG
+       | Unknown of string
 
 let of_string s = match s with
   | "CODE" -> CODE | "DLPT" -> DLPT | "DLLS" -> DLLS | "PRIM" -> PRIM
   | "DATA" -> DATA | "SYMB" -> SYMB | "CRCS" -> CRCS | "DBUG" -> DBUG
-  | _      -> Tools.fail "unknown section %S" s
+  | _      -> Unknown s
 
 let to_string ty = match ty with
   | CODE -> "CODE" | DLPT -> "DLPT" | DLLS -> "DLLS" | PRIM -> "PRIM"
   | DATA -> "DATA" | SYMB -> "SYMB" | CRCS -> "CRCS" | DBUG -> "DBUG"
+  | Unknown s ->
+    if String.length s <> 4 then
+      invalid_arg (
+        "OByteLib.Section.to_string: Sections should be only \
+         4 characters: "^s)
+    else
+      s


### PR DESCRIPTION
As you surely know, the bytecode doesn't technically mandate that only the recognized eight section appears in a file. The bytecode can also contains arbitrary other "sections", which ocamlrun will not read. With this patch, obytelib can read and write file containing such sections and can manipulate them.

This change allowed me to write [bytepdf](https://github.com/Drup/bytepdf) which is a library that allows to create a file that is both a valid pdf and a valid bytecode by abusing sections (and the PDF format).