### PR TITLE
Workaround for bug with caml_sys_argv

### DIFF
--- a/configure
+++ b/configure
@@ -91,7 +91,8 @@ PRIMS=$($OCAMLRUN -p |
   grep -v caml_spacetime_only_works_for_native_code |
   grep -v caml_register_code_fragment |
   grep -v caml_get_current_environment |
-  grep -v caml_ensure_stack_capacity)
+  grep -v caml_ensure_stack_capacity |
+  grep -v caml_sys_argv)
 
 echo "\
 include Strsec.Make(struct let section = Section.PRIM end)
@@ -123,6 +124,7 @@ done
 echo "\
   | 1, \"caml_ensure_stack_capacity\" -> Obj.repr (fun _ -> ())
   | 1, \"caml_is_printable\" -> Obj.repr (fun _ -> true)
+  | 1, \"caml_sys_argv\" -> Obj.repr (fun _ -> Sys.argv)
 
   | _ -> Tools.fail \"external function %S of arity %d not found\" name arity
 


### PR DESCRIPTION
There's a hack in the compiler that miscompiles the `caml_sys_argv` primitive if it's declared as an external directly (it's supposed to be exposed through the `"%sys_argv"` builtin primitive, not directly).
I'm not sure exactly why it never was an issue before, but I believe that without this patch trying to call the `caml_sys_argv` primitive through the generated `Prim` module will cause a segmentation fault.